### PR TITLE
Improve reconnection mechanism

### DIFF
--- a/MZFayeClient/MZFayeClient.m
+++ b/MZFayeClient/MZFayeClient.m
@@ -434,7 +434,7 @@ NSInteger const MZFayeClientDefaultMaximumAttempts = 5;
 {
     if (self.shouldRetryConnection && self.retryAttempt < self.maximumRetryAttempts) {
 
-        self.reconnectTimer = [NSTimer scheduledTimerWithTimeInterval:self.retryInterval target:self selector:@selector(reconnectTimer:) userInfo:nil repeats:YES];
+        self.reconnectTimer = [NSTimer scheduledTimerWithTimeInterval:self.retryInterval target:self selector:@selector(reconnectTimer:) userInfo:nil repeats:NO];
     }
 }
 


### PR DESCRIPTION
There are 2 issues fixed by this pull request: 
- webSocket: didFailWithError: method is called by SocketRocket when connection dropped, so reconnection mechanism should be launched
- reconnection NSTimer was set incorrectly (as repeating), so it fired multiple times 
