### PR TITLE
Add ability to check for success or failure after publishing a message

### DIFF
--- a/Example/MZFayeClient.xcodeproj/project.pbxproj
+++ b/Example/MZFayeClient.xcodeproj/project.pbxproj
@@ -54,8 +54,9 @@
 		062344B918592B2F0052DB3E /* MZFayeClientTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "MZFayeClientTests-Info.plist"; sourceTree = "<group>"; };
 		062344BB18592B2F0052DB3E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		062344BD18592B2F0052DB3E /* MZFayeClientTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MZFayeClientTests.m; sourceTree = "<group>"; };
-		3E133F42E01E4D6D80C19CB0 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 		6A15FC3517F64F34939D2995 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8C360882D754D9347EFBA7D9 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		D8A6F6A8594C720BFA45AB7A /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,7 +91,7 @@
 				062344B718592B2F0052DB3E /* MZFayeClientTests */,
 				0623449118592B2F0052DB3E /* Frameworks */,
 				0623449018592B2F0052DB3E /* Products */,
-				3E133F42E01E4D6D80C19CB0 /* Pods.xcconfig */,
+				17FDEC09305CD15621E03900 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -156,6 +157,15 @@
 				062344BA18592B2F0052DB3E /* InfoPlist.strings */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		17FDEC09305CD15621E03900 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D8A6F6A8594C720BFA45AB7A /* Pods.debug.xcconfig */,
+				8C360882D754D9347EFBA7D9 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -281,7 +291,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -417,7 +427,7 @@
 		};
 		062344C218592B2F0052DB3E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3E133F42E01E4D6D80C19CB0 /* Pods.xcconfig */;
+			baseConfigurationReference = D8A6F6A8594C720BFA45AB7A /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -432,7 +442,7 @@
 		};
 		062344C318592B2F0052DB3E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3E133F42E01E4D6D80C19CB0 /* Pods.xcconfig */;
+			baseConfigurationReference = 8C360882D754D9347EFBA7D9 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,2 +1,2 @@
 platform :ios, '6.0'
-pod 'MZFayeClient', '~> 1.0.0'
+pod 'MZFayeClient', :path => '../'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,0 +1,20 @@
+PODS:
+  - Base64 (1.0.1)
+  - MZFayeClient (1.0.1):
+    - Base64 (~> 1.0.1)
+    - SocketRocket (~> 0.3.1-beta2)
+  - SocketRocket (0.3.1-beta2)
+
+DEPENDENCIES:
+  - MZFayeClient (from `../`)
+
+EXTERNAL SOURCES:
+  MZFayeClient:
+    :path: "../"
+
+SPEC CHECKSUMS:
+  Base64: 4924bf3ca6fa559a5161ef717291bd450eb7bd1a
+  MZFayeClient: 0249736408974dc5edb268bf3b96c579a8089450
+  SocketRocket: 7284ab9370a06c99aba92b2fe3a32aedd0f9a6fa
+
+COCOAPODS: 0.38.2

--- a/MZFayeClient/MZFayeClient.h
+++ b/MZFayeClient/MZFayeClient.h
@@ -41,6 +41,9 @@ extern NSInteger      const MZFayeClientDefaultMaximumAttempts;
 
 typedef void(^MZFayeClientSubscriptionHandler)(NSDictionary *message);
 
+typedef void (^MZPublishSuccessHandler)();
+typedef void (^MZPublishFailureHandler)(NSError *error);
+
 @protocol MZFayeClientDelegate <NSObject>
 @optional
 
@@ -132,8 +135,11 @@ typedef void(^MZFayeClientSubscriptionHandler)(NSDictionary *message);
 - (void)setExtension:(NSDictionary *)extension forChannel:(NSString *)channel;
 - (void)removeExtensionForChannel:(NSString *)channel;
 
-- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel;
-- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension;
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel DEPRECATED_MSG_ATTRIBUTE("Use sendMessage:toChannel:success:failure:");
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension DEPRECATED_MSG_ATTRIBUTE("Use sendMessage:toChannel:usingExtension:success:failure:");
+
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel success:(MZPublishSuccessHandler)successHandler failure:(MZPublishFailureHandler)failureHandler;
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension success:(MZPublishSuccessHandler)successHandler failure:(MZPublishFailureHandler)failureHandler;
 
 - (void)subscribeToChannel:(NSString *)channel;
 - (void)subscribeToChannel:(NSString *)channel usingBlock:(MZFayeClientSubscriptionHandler)subscriptionHandler;

--- a/MZFayeClient/MZFayeClient.h
+++ b/MZFayeClient/MZFayeClient.h
@@ -35,6 +35,12 @@ extern NSString *const MZFayeClientBayeuxChannelSubscribe;
 extern NSString *const MZFayeClientBayeuxChannelUnsubscribe;
 
 extern NSString *const MZFayeClientWebSocketErrorDomain;
+extern NSString *const MZFayeClientBayeuxErrorDomain;
+
+typedef NS_ENUM(NSInteger, MZFayeClientBayeuxError) {
+    MZFayeClientBayeuxErrorReceivedFailureStatus = -100,
+    MZFayeClientBayeuxErrorCouldNotParse = -101,
+};
 
 extern NSTimeInterval const MZFayeClientDefaultRetryInterval;
 extern NSInteger      const MZFayeClientDefaultMaximumAttempts;

--- a/MZFayeClient/MZFayeClient.m
+++ b/MZFayeClient/MZFayeClient.m
@@ -587,7 +587,7 @@ NSInteger const MZFayeClientDefaultMaximumAttempts = 5;
 
         } else if ([self.openChannelSubscriptions containsObject:fayeMessage.channel]) {
             
-            if ([self.pendingMessages.allKeys containsObject:fayeMessage.Id]) {
+            if ([self.pendingMessages.allKeys containsObject:fayeMessage.Id] && fayeMessage.successful != nil) {
                 // This is a response to a message we published
                 
                 NSDictionary *handlers = self.pendingMessages[fayeMessage.Id];

--- a/MZFayeClient/MZFayeClient.m
+++ b/MZFayeClient/MZFayeClient.m
@@ -319,7 +319,7 @@ NSInteger const MZFayeClientDefaultMaximumAttempts = 5;
 {
     self.sentMessageCount++;
 
-    return [[NSString stringWithFormat:@"%d",self.sentMessageCount] base64String];
+    return [[NSString stringWithFormat:@"%ld", (long)self.sentMessageCount] base64String];
 }
 
 #pragma mark - Public methods

--- a/MZFayeClient/MZFayeClient.m
+++ b/MZFayeClient/MZFayeClient.m
@@ -52,7 +52,8 @@ NSString *const MZFayeClientBayeuxConnectionTypeCallbackPolling = @"callback-pol
 NSString *const MZFayeClientBayeuxConnectionTypeIFrame = @"iframe";
 NSString *const MZFayeClientBayeuxConnectionTypeWebSocket = @"websocket";
 
-NSString *const MZFayeClientWebSocketErrorDomain = @"com.mzfayeclient.error";
+NSString *const MZFayeClientWebSocketErrorDomain = @"com.mzfayeclient.error.web-socket";
+NSString *const MZFayeClientBayeuxErrorDomain = @"com.mzfayeclient.error.bayeux";
 
 NSTimeInterval const MZFayeClientDefaultRetryInterval = 1.0f;
 NSInteger const MZFayeClientDefaultMaximumAttempts = 5;
@@ -493,7 +494,7 @@ NSInteger const MZFayeClientDefaultMaximumAttempts = 5;
 - (void)didFailWithMessage:(NSString *)message
 {
     if ([self.delegate respondsToSelector:@selector(fayeClient:didFailWithError:)] && message) {
-        NSError *error = [NSError errorWithDomain:MZFayeClientWebSocketErrorDomain code:-100 userInfo:@{NSLocalizedDescriptionKey : message}];
+        NSError *error = [NSError errorWithDomain:MZFayeClientBayeuxErrorDomain code:MZFayeClientBayeuxErrorReceivedFailureStatus userInfo:@{NSLocalizedDescriptionKey : message}];
         [self.delegate fayeClient:self didFailWithError:error];
     }
 }
@@ -504,7 +505,7 @@ NSInteger const MZFayeClientDefaultMaximumAttempts = 5;
 
         if (![message isKindOfClass:[NSDictionary class]]) {
             if ([self.delegate respondsToSelector:@selector(fayeClient:didFailWithError:)]) {
-                NSError *error = [NSError errorWithDomain:MZFayeClientWebSocketErrorDomain code:-100 userInfo:@{NSLocalizedDescriptionKey : @"Message is not kind of NSDicitionary class"}];
+                NSError *error = [NSError errorWithDomain:MZFayeClientBayeuxErrorDomain code:MZFayeClientBayeuxErrorCouldNotParse userInfo:@{NSLocalizedDescriptionKey : @"Message is not kind of NSDicitionary class"}];
                 [self.delegate fayeClient:self didFailWithError:error];
             }
             return;
@@ -602,7 +603,7 @@ NSInteger const MZFayeClientDefaultMaximumAttempts = 5;
                         
                         id fayeErrorOrNull = fayeMessage.error;
                         if (fayeErrorOrNull == nil) fayeErrorOrNull = NSNull.null;
-                        NSError *error = [NSError errorWithDomain:MZFayeClientWebSocketErrorDomain code:-101 userInfo:@{NSLocalizedDescriptionKey : @"The operation could not be completed.", @"fayeError": fayeErrorOrNull}];
+                        NSError *error = [NSError errorWithDomain:MZFayeClientBayeuxErrorDomain code:MZFayeClientBayeuxErrorReceivedFailureStatus userInfo:@{NSLocalizedDescriptionKey : @"Faye server rejected published message", NSLocalizedFailureReasonErrorKey: fayeErrorOrNull}];
                         
                         failureHandler(error);
                     }

--- a/MZFayeClient/MZFayeMessage.m
+++ b/MZFayeClient/MZFayeMessage.m
@@ -27,30 +27,36 @@
 
 @implementation MZFayeMessage
 
-- (instancetype)initFromDictionary:(NSDictionary *)dictionary
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
-    if (self = [super init]) {
-        self.Id = dictionary[@"id"];
-        self.channel = dictionary[@"channel"];
-        self.clientId = dictionary[@"clientId"];
-        self.successful = @([dictionary[@"successful"] boolValue]);
-        self.authSuccessful = @([dictionary[@"authSuccessful"] boolValue]);
-        self.version = dictionary[@"version"];
-        self.minimumVersion = dictionary[@"minimumVersion"];
-        self.supportedConnectionTypes = dictionary[@"supportedConnectionTypes"];
-        self.advice = dictionary[@"advice"];
-        self.error = dictionary[@"error"];
-        self.subscription = dictionary[@"subscription"];
-        self.timestamp = [NSDate dateWithTimeIntervalSince1970:[dictionary[@"timestamp"] timeInterval]];
-        self.data = dictionary[@"data"];
-        self.ext = dictionary[@"ext"];
+    self = [super init];
+    if (self) {
+        [self importFromDictionary:dictionary];
     }
     return self;
 }
 
 + (instancetype)messageFromDictionary:(NSDictionary *)dictionary
 {
-    return [[[self class] alloc] initFromDictionary:dictionary];
+    return [[[self class] alloc] initWithDictionary:dictionary];
+}
+
+- (void)importFromDictionary:(NSDictionary *)dictionary
+{
+    if (dictionary[@"id"] != nil) {
+        self.Id = dictionary[@"id"];
+    }
+    
+    if (dictionary[@"timestamp"] != nil) {
+        self.timestamp = [NSDate dateWithTimeIntervalSince1970:[dictionary[@"timestamp"] timeInterval]];
+    }
+    
+    NSArray *objectAttributes = @[@"channel", @"clientId", @"successful", @"authSuccessful", @"version", @"minimumVersion", @"supportedConnectionTypes", @"advice", @"error", @"subscription", @"data", @"ext"];
+    for (NSString *attribute in objectAttributes) {
+        if (dictionary[attribute] != nil) {
+            [self setValue:dictionary[attribute] forKey:attribute];
+        }
+    }
 }
 
 @end


### PR DESCRIPTION
My Faye server will reject an attempt to publish a message if it does not meet certain criteria; therefore, in my client, I needed a way to detect the success or failure of an attempt to publish.

[The official JavaScript client can do this:][1]

    var publication = client.publish('/foo', {text: 'Hi there'});
    
    publication.then(function() {
      alert('Message received by server!');
    }, function(error) {
      alert('There was a problem: ' + error.message);
    });

To accomplish this in MZFayeClient, I have extended the methods `- sendMessage:toChannel:` and `- sendMessage:toChannel:usingExtension:` to accept additional parameters, `success:` and `failure:`, as blocks.

The original versions of those methods (without the added parameters) still exist, but I guessed that if this PR is accepted, you might want to remove them in a future version, so I marked them deprecated. If this is undesirable, I can remove the deprecation flags.

This works by looking for a 'response' message from the server with the same `id` as one that we published, and then checking whether the `successful` flag is `true` or `false`. If an incoming message is not a 'response', then it will not have a `successful` attribute.

Note that technically, the [Bayeux protocol says][2] that the server sending a response to a published message is *optional*; therefore, when used with a conforming Bayeux server, it is possible that the `success` and `failure` blocks may never be called. This is potentially something for clients to be aware of. However, in practice, the official Faye server always sends back a response, as far as I can tell. Since this is a 'Faye client', rather than a 'Bayeux client', this seemed OK.

Thanks for reading my PR; I'm open to feedback.

[1]: http://faye.jcoglan.com/browser/publishing.html
[2]: http://svn.cometd.org/trunk/bayeux/bayeux.html#toc_66