### PR TITLE
Add block handlers for success or failure, for subscribe/unsubscribe/connect/disconnect

### DIFF
--- a/MZFayeClient/MZFayeClient.h
+++ b/MZFayeClient/MZFayeClient.h
@@ -138,8 +138,8 @@ typedef void (^MZFayeClientFailureHandler)(NSError *error);
  */
 @property (nonatomic, weak) id <MZFayeClientDelegate> delegate;
 
-- (instancetype)init;
-+ (instancetype)client;
+- (instancetype)init DEPRECATED_MSG_ATTRIBUTE("Use -initWithURL:");
++ (instancetype)client DEPRECATED_MSG_ATTRIBUTE("Use +clientWithURL:");
 
 - (instancetype)initWithURL:(NSURL *)url;
 + (instancetype)clientWithURL:(NSURL *)url;
@@ -160,9 +160,13 @@ typedef void (^MZFayeClientFailureHandler)(NSError *error);
 - (void)subscribeToChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler receivedMessage:(MZFayeClientSubscriptionHandler)subscriptionHandler;
 - (void)unsubscribeFromChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
 
-- (BOOL)connectToURL:(NSURL *)url;
-- (BOOL)connect;
+- (BOOL)connectToURL:(NSURL *)url DEPRECATED_MSG_ATTRIBUTE("Use -connect:failure:");
+- (BOOL)connect DEPRECATED_MSG_ATTRIBUTE("Use -connect:failure:");
 
-- (void)disconnect;
+- (void)connect:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
+
+- (void)disconnect DEPRECATED_MSG_ATTRIBUTE("Use -disconnect:failure:");
+
+- (void)disconnect:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
 
 @end

--- a/MZFayeClient/MZFayeClient.h
+++ b/MZFayeClient/MZFayeClient.h
@@ -36,10 +36,16 @@ extern NSString *const MZFayeClientBayeuxChannelUnsubscribe;
 
 extern NSString *const MZFayeClientWebSocketErrorDomain;
 extern NSString *const MZFayeClientBayeuxErrorDomain;
+extern NSString *const MZFayeClientErrorDomain;
 
 typedef NS_ENUM(NSInteger, MZFayeClientBayeuxError) {
     MZFayeClientBayeuxErrorReceivedFailureStatus = -100,
     MZFayeClientBayeuxErrorCouldNotParse = -101,
+};
+
+typedef NS_ENUM(NSInteger, MZFayeClientError) {
+    MZFayeClientErrorAlreadySubscribed,
+    MZFayeClientErrorNotSubscribed,
 };
 
 extern NSTimeInterval const MZFayeClientDefaultRetryInterval;
@@ -147,9 +153,12 @@ typedef void (^MZFayeClientFailureHandler)(NSError *error);
 - (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
 - (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
 
-- (void)subscribeToChannel:(NSString *)channel;
-- (void)subscribeToChannel:(NSString *)channel usingBlock:(MZFayeClientSubscriptionHandler)subscriptionHandler;
-- (void)unsubscribeFromChannel:(NSString *)channel;
+- (void)subscribeToChannel:(NSString *)channel DEPRECATED_MSG_ATTRIBUTE("Use -subscribeToChannel:success:failure:receivedMessage:");
+- (void)subscribeToChannel:(NSString *)channel usingBlock:(MZFayeClientSubscriptionHandler)subscriptionHandler DEPRECATED_MSG_ATTRIBUTE("Use -subscribeToChannel:success:failure:receivedMessage:");
+- (void)unsubscribeFromChannel:(NSString *)channel DEPRECATED_MSG_ATTRIBUTE("Use -unsubscribeFromChannel:success:failure:");
+
+- (void)subscribeToChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler receivedMessage:(MZFayeClientSubscriptionHandler)subscriptionHandler;
+- (void)unsubscribeFromChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
 
 - (BOOL)connectToURL:(NSURL *)url;
 - (BOOL)connect;

--- a/MZFayeClient/MZFayeClient.h
+++ b/MZFayeClient/MZFayeClient.h
@@ -47,8 +47,8 @@ extern NSInteger      const MZFayeClientDefaultMaximumAttempts;
 
 typedef void(^MZFayeClientSubscriptionHandler)(NSDictionary *message);
 
-typedef void (^MZPublishSuccessHandler)();
-typedef void (^MZPublishFailureHandler)(NSError *error);
+typedef void (^MZFayeClientSuccessHandler)();
+typedef void (^MZFayeClientFailureHandler)(NSError *error);
 
 @protocol MZFayeClientDelegate <NSObject>
 @optional
@@ -141,11 +141,11 @@ typedef void (^MZPublishFailureHandler)(NSError *error);
 - (void)setExtension:(NSDictionary *)extension forChannel:(NSString *)channel;
 - (void)removeExtensionForChannel:(NSString *)channel;
 
-- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel DEPRECATED_MSG_ATTRIBUTE("Use sendMessage:toChannel:success:failure:");
-- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension DEPRECATED_MSG_ATTRIBUTE("Use sendMessage:toChannel:usingExtension:success:failure:");
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel DEPRECATED_MSG_ATTRIBUTE("Use -sendMessage:toChannel:success:failure:");
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension DEPRECATED_MSG_ATTRIBUTE("Use -sendMessage:toChannel:usingExtension:success:failure:");
 
-- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel success:(MZPublishSuccessHandler)successHandler failure:(MZPublishFailureHandler)failureHandler;
-- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension success:(MZPublishSuccessHandler)successHandler failure:(MZPublishFailureHandler)failureHandler;
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
 
 - (void)subscribeToChannel:(NSString *)channel;
 - (void)subscribeToChannel:(NSString *)channel usingBlock:(MZFayeClientSubscriptionHandler)subscriptionHandler;

--- a/README.md
+++ b/README.md
@@ -2,27 +2,78 @@ MZFayeClient
 ===========
 
 Faye Client for iOS. 
-This project is an rewritten version of the Library made by pcrawfor there: <https://github.com/pcrawfor/FayeObjC>
+This project is a rewritten version of the library made by pcrawfor there: <https://github.com/pcrawfor/FayeObjC>
 Improved capture errors, added subscription blocks, ability to set the extension for channel.
 Added auto connection reconnect, and many more...
 
-## How To Use
+## How To Use - Example
 
-``` objective-c
+```
 self.client = [[MZFayeClient alloc] initWithURL:[NSURL URLWithString:@"ws://localhost:9292/faye"]];
 
-    [self.client subscribeToChannel:@"/server" usingBlock:^(NSDictionary *message) {
-        NSLog(@"Server %@",message);
-    }];
+[self.client subscribeToChannel:@"/server" success:^{
+    NSLog(@"Subscribed successfully to 'server' channel!");
+} failure:^(NSError *) {
+    NSLog(@"Error subscribing to 'server' channel: %@", error.userInfo);
+} receivedMessage:^(NSDictionary *message) {
+    NSLog(@"Message on 'server' channel: %@", message);
+}];
 
-    [self.client subscribeToChannel:@"/browser" usingBlock:^(NSDictionary *message) {
-        NSLog(@"Browser %@",message);
+[self.client subscribeToChannel:@"/browser" success:nil failure:nil receivedMessage:^(NSDictionary *message) {
+    NSLog(@"Message on 'browser' channel: %@", message);
+}];
+
+[self.client connect:^{
+    [self.client sendMessage:@{@"text": @"hello!"} toChannel:@"/server" success:^{
+        NSLog(@"Message sent successfully.");
+    } failure:^(NSError *)error {
+        NSLog(@"Error sending message: %@", error.userInfo);
     }];
-    
-    [self.client connect];
+} failure:^(NSError *) {
+    NSLog(@"Error connecting: %@", error.userInfo);
+}];
 ```
 
-## Delagate
+## Available methods
+
+### Initializing
+```
+- (instancetype)initWithURL:(NSURL *)url;
++ (instancetype)clientWithURL:(NSURL *)url;
+```
+
+### Publishing
+```
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
+- (void)sendMessage:(NSDictionary *)message toChannel:(NSString *)channel usingExtension:(NSDictionary *)extension success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
+```
+
+### Subscribing/unsubscribing
+```
+- (void)subscribeToChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler receivedMessage:(MZFayeClientSubscriptionHandler)subscriptionHandler;
+- (void)unsubscribeFromChannel:(NSString *)channel success:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
+```
+
+### Connecting/disconnecting
+```
+- (void)connect:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
+- (void)disconnect:(MZFayeClientSuccessHandler)successHandler failure:(MZFayeClientFailureHandler)failureHandler;
+```
+
+### Using Faye extensions
+
+For more info about extensions, see the [Faye site](http://faye.jcoglan.com/node/extensions.html),
+
+```
+- (void)setExtension:(NSDictionary *)extension forChannel:(NSString *)channel;
+- (void)removeExtensionForChannel:(NSString *)channel;
+```
+
+## Delegate protocol
+
+Many delegate methods can be accomplished with blocks instead, but they still exist for those who prefer this way.
+
+**Note:** In `-connect:failure:`, the `successHandler` and `failureHandlers` will only be called the first time the connection succeeds or fails. Due to automatic reconnection logic, such events may happen multiple times. If you need to handle connection success or failure every time it happens, you should use the delegate methods instead (or in addition).
 
 ```
 @protocol MZFayeClientDelegate <NSObject>
@@ -54,7 +105,8 @@ rackup faye.ru -s thin -E production
 curl http://localhost:9292/faye -d 'message={"channel":"/server", "data":"hello"}'
 ```
 
-##Dependencies
+## Dependencies
+
 #### SocketRocket
 A conforming WebSocket (RFC 6455) client library maintained by Square, 
 <https://github.com/square/SocketRocket>


### PR DESCRIPTION
Continuing my line of thought from #9, with a similar rationale: my Faye server will reject an attempt to subscribe to a channel based on certain criteria; therefore, in my client, I needed a way to detect the success or failure of an attempt to subscribe.

The delegate method `-fayeClient:didFailWithError:` was insufficient in this case, because it does not distinguish between causes of failures. However, rather than change its behavior, I opted to continue a block-based approach as before.

Since I had come this far, I decided to continue adding block support for unsubscribe, connect, and disconnect, as well. At this point, I think just about every use case of this library is now covered with block handlers.

I also updated the Readme and deprecations to reflect this. As always, feedback is welcome. Thanks :)